### PR TITLE
add doc and yaml file for metricly heapster deployment instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The current version of Storage Schema is documented [here](docs/storage-schema.m
 ### Running Heapster on Kubernetes
 
 Heapster can run on a Kubernetes cluster using a number of backends.  Some common choices:
-- [InfluxDB](docs/influxdb.md)
+- [Metricly](docs/metricly.md)
 - [Stackdriver Monitoring and Logging](docs/google.md) for Google Cloud Platform
 - [Other backends](docs/)
 

--- a/common/metricly/metricly.go
+++ b/common/metricly/metricly.go
@@ -46,7 +46,7 @@ type MetriclyConfig struct {
 
 func Config(uri *url.URL) (MetriclyConfig, error) {
 	config := MetriclyConfig{
-		ApiURL: "https://api.app.metricly.com/ingest",
+		ApiURL: "https://api.app.metricly.com/ingest/kubernetes",
 		ApiKey: "",
 	}
 

--- a/common/metricly/metricly_test.go
+++ b/common/metricly/metricly_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestParsingMetriclyConfig(t *testing.T) {
 	//given
-	metriclyURI := "https://api.app.metricly.com/ingest?apiKey=datasourceApiKey&elementBatchSize=60&filter=label:{type:pod.*}&filter=!label:{type:pod_container}"
+	metriclyURI := "https://api.app.metricly.com/ingest/kubernetes?apiKey=datasourceApiKey&elementBatchSize=60&filter=label:{type:pod.*}&filter=!label:{type:pod_container}"
 	uri, err := url.Parse(metriclyURI)
 	if err != nil {
 		t.Fatalf("Error when parsing Metricly URL: %s", err.Error())
@@ -31,8 +31,8 @@ func TestParsingMetriclyConfig(t *testing.T) {
 		t.Fatalf("Error when configuring Metricly URL: %s", err.Error())
 	}
 	//then
-	if config.ApiURL != "https://api.app.metricly.com/ingest" {
-		t.Fatalf("The Api URL is wrong, actual=%s, expected=%s", config.ApiURL, "https://api.app.metricly.com/ingest")
+	if config.ApiURL != "https://api.app.metricly.com/ingest/kubernetes" {
+		t.Fatalf("The Api URL is wrong, actual=%s, expected=%s", config.ApiURL, "https://api.app.metricly.com/ingest/kubernetes")
 	}
 	if config.ApiKey != "datasourceApiKey" {
 		t.Fatalf("The Api Key is wrong, actual=%s, expected=%s", config.ApiKey, "datasourceApiKey")

--- a/deploy/kube-config/metricly/heapster.yaml
+++ b/deploy/kube-config/metricly/heapster.yaml
@@ -25,7 +25,7 @@ spec:
         command:
         - /heapster
         - --source=kubernetes:https://kubernetes.default
-        - --sink=metricly:https://api.app.metricly.com/ingest?apiKey={apiKey}
+        - --sink=metricly:https://api.app.metricly.com/ingest/kubernetes?apiKey={apiKey}
 ---
 apiVersion: v1
 kind: Service

--- a/deploy/kube-config/metricly/heapster.yaml
+++ b/deploy/kube-config/metricly/heapster.yaml
@@ -1,0 +1,46 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: heapster
+  namespace: kube-system
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: heapster
+  namespace: kube-system
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        task: monitoring
+        k8s-app: heapster
+    spec:
+      serviceAccountName: heapster
+      containers:
+      - name: heapster
+        image: index.docker.io/metricly/heapster:0.0.5
+        imagePullPolicy: IfNotPresent
+        command:
+        - /heapster
+        - --source=kubernetes:https://kubernetes.default
+        - --sink=metricly:https://api.app.metricly.com/ingest?apiKey={apiKey}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    task: monitoring
+    # For use as a Cluster add-on (https://github.com/kubernetes/kubernetes/tree/master/cluster/addons)
+    # If you are using this as an addon, you should uncomment this line.
+    # kubernetes.io/cluster-service: 'true'
+    # kubernetes.io/name: Heapster
+  name: heapster
+  namespace: kube-system
+spec:
+  ports:
+  - port: 80
+    targetPort: 8082
+  selector:
+    k8s-app: heapster

--- a/docs/metricly.md
+++ b/docs/metricly.md
@@ -1,0 +1,36 @@
+# Run Heapster in a Kubernetes cluster with a Metricly Sink that pushes data to Metricly Cloud
+
+### Setup a Kubernetes cluster
+[Bring up a Kubernetes cluster](https://github.com/kubernetes/kubernetes), if you haven't already.
+Ensure that you are able to interact with the cluster via `kubectl` (this may be `kubectl.sh` if using
+the local-up-cluster in the Kubernetes repository).
+
+### Start Metricly Heapster pod and service
+Ensure that you have a valid checkout of [Heapster](https://github.com/metricly/heapster) and are in the root directory of the Heapster repository, and then run
+
+```shell
+$ kubectl create -f deploy/kube-config/metricly/heapster.yaml
+```
+See also the [Sink Configuration](sink-configuration.md) Metricly Section for more advanced configurations, e.g. filters.
+
+## Troubleshooting guide
+
+See also the [debugging documentation](debugging.md).
+
+1. If there are no Kubernetes elements shown up in Metricly Inventory after about 5 minutes, heapster might not be running properly with the configured Metricly Sink. Use `kubectl` to verify that the `heapster` pod and service is alive and check the pod logs.
+    ```
+    $ kubectl get pods --namespace=kube-system
+    ...
+    heapster-5bb59685bd-75f4x                          1/1       Running    2          22d
+    ...
+    
+    $ kubectl get services --namespace=kube-system heapster
+    NAME       TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)   AGE
+    heapster   ClusterIP   10.101.65.65   <none>        80/TCP    34d
+
+    $ kubectl --namespace=kube-system logs heapster-5bb59685bd-75f4x
+    ...
+    I0517 15:08:05.134683       1 metricly.go:49] Start exporting data batch to Metricly ...
+    I0517 15:08:05.241484       1 metricly.go:79] Exported 85 out of 85 elements using 5 workers
+    ...
+    ```

--- a/docs/sink-configuration.md
+++ b/docs/sink-configuration.md
@@ -380,7 +380,7 @@ Options can be set in query string, like this:
 
 For example,
 
-    --sink="metricly:https://api.app.metricly.com/ingest?apiKey=<uuid>"
+    --sink="metricly:https://api.app.metricly.com/ingest/kubernetes?apiKey=<uuid>"
 
 ## Using multiple sinks
 


### PR DESCRIPTION
add instructions on Metricly sink enabled heapster deployment.

