### PR TITLE
fixes #14 add cluster configuration support to metricly sink

### DIFF
--- a/common/metricly/metricly.go
+++ b/common/metricly/metricly.go
@@ -39,6 +39,7 @@ type Filter struct {
 type MetriclyConfig struct {
 	ApiURL                string
 	ApiKey                string
+	ClusterName           string
 	ElementBatchSize      int
 	InclusionFilters      []Filter
 	ExclusionFilters      []Filter
@@ -88,6 +89,9 @@ func Config(uri *url.URL) (MetriclyConfig, error) {
 		if mcttl, err := strconv.Atoi(opts["metricCacheTTLSeconds"][0]); mcttl > 0 && err == nil {
 			config.MetricCacheTTLSeconds = mcttl
 		}
+	}
+	if len(opts["cluster"]) > 0 {
+		config.ClusterName = opts["cluster"][0]
 	}
 	return config, nil
 }

--- a/common/metricly/metricly_test.go
+++ b/common/metricly/metricly_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestParsingMetriclyConfig(t *testing.T) {
 	//given
-	metriclyURI := "https://api.app.metricly.com/ingest/kubernetes?apiKey=datasourceApiKey&elementBatchSize=60&filter=label:{type:pod.*}&filter=!label:{type:pod_container}&metricCacheTTLSeconds=120"
+	metriclyURI := "https://api.app.metricly.com/ingest/kubernetes?cluster=qa&apiKey=datasourceApiKey&elementBatchSize=60&filter=label:{type:pod.*}&filter=!label:{type:pod_container}&metricCacheTTLSeconds=120"
 	uri, err := url.Parse(metriclyURI)
 	if err != nil {
 		t.Fatalf("Error when parsing Metricly URL: %s", err.Error())
@@ -36,6 +36,9 @@ func TestParsingMetriclyConfig(t *testing.T) {
 	}
 	if config.ApiKey != "datasourceApiKey" {
 		t.Fatalf("The Api Key is wrong, actual=%s, expected=%s", config.ApiKey, "datasourceApiKey")
+	}
+	if config.ClusterName != "qa" {
+		t.Fatalf("The cluster name is wrong, actual=%s, expected=%s", config.ClusterName, "qa")
 	}
 	if config.ElementBatchSize != 60 {
 		t.Fatalf("The Element Batch Size is wrong, actual=%d, expected=%d", config.ElementBatchSize, 60)

--- a/docs/sink-configuration.md
+++ b/docs/sink-configuration.md
@@ -373,6 +373,7 @@ To use the Metricly sink add the following flag:
 
 Options can be set in query string, like this:
 
+* `cluster` - Cluster name for different Kubernetes clusters. Default value is `k8s-cluster`.
 * `apiKey` - Metricly kubernetes datasource api key
 * `elementBatchSize` - Number of elements per payload that is sent to Metricly, the default size is `20`
 * `filter` - Allows including or excluding metric sets to be posted to Metricly, any number of filter parameters can be given with a syntax of `filter=label:{type:pod.*}` and/or `filter=!label:{type:pod_container}`. Right now, only `label` filter type is supported and its name and value regex are separated by `:`. The `!` before the `label` means it is an exculsion filter.

--- a/metrics/sinks/metricly/metricly.go
+++ b/metrics/sinks/metricly/metricly.go
@@ -28,12 +28,14 @@ const (
 	defaultElementsPayloadSize   = 20
 	defaultMetricCacheTTLSeconds = 300
 	elementTypePrefix            = "Kubernetes "
+	defaultClusterName           = "k8s-cluster"
 )
 
 type MetriclyMetricsSink struct {
-	client api.Client
-	config metricly.MetriclyConfig
-	cache  *MetricCache
+	client  api.Client
+	config  metricly.MetriclyConfig
+	cache   *MetricCache
+	cluster string
 }
 
 func (sink *MetriclyMetricsSink) Name() string {
@@ -49,7 +51,7 @@ type chunk struct {
 
 func (sink *MetriclyMetricsSink) ExportData(batch *core.DataBatch) {
 	glog.Info("Start exporting data batch to Metricly ...")
-	elements := DataBatchToElements(sink.config, sink.cache, batch)
+	elements := DataBatchToElements(sink.cluster+"/", sink.config, sink.cache, batch)
 	elementsPayloadSize := defaultElementsPayloadSize
 	if sink.config.ElementBatchSize > 0 {
 		elementsPayloadSize = sink.config.ElementBatchSize
@@ -88,10 +90,14 @@ func NewMetriclySink(uri *url.URL) (core.DataSink, error) {
 	if config.MetricCacheTTLSeconds > 0 {
 		mcttl = config.MetricCacheTTLSeconds
 	}
-	return &MetriclyMetricsSink{client: api.NewClient(config.ApiURL, config.ApiKey), config: config, cache: NewMetricCache(mcttl)}, nil
+	clusterName := defaultClusterName
+	if len(config.ClusterName) > 0 {
+		clusterName = config.ClusterName
+	}
+	return &MetriclyMetricsSink{client: api.NewClient(config.ApiURL, config.ApiKey), config: config, cache: NewMetricCache(mcttl), cluster: clusterName}, nil
 }
 
-func DataBatchToElements(config metricly.MetriclyConfig, cache *MetricCache, batch *core.DataBatch) []metricly_core.Element {
+func DataBatchToElements(cluster string, config metricly.MetriclyConfig, cache *MetricCache, batch *core.DataBatch) []metricly_core.Element {
 	ts := batch.Timestamp.Unix() * 1000
 	var elements []metricly_core.Element
 	for key, ms := range batch.MetricSets {
@@ -100,7 +106,7 @@ func DataBatchToElements(config metricly.MetriclyConfig, cache *MetricCache, bat
 			continue
 		}
 		etype := ms.Labels["type"]
-		element := metricly_core.NewElement(key, shortenName(key), prettyElementType(etype), "")
+		element := metricly_core.NewElement(cluster+key, cluster+shortenName(key), prettyElementType(etype), "")
 		// metric set labels to element tags
 		for lname, lvalue := range ms.Labels {
 			if lname == "labels" {

--- a/metrics/sinks/metricly/metricly_test.go
+++ b/metrics/sinks/metricly/metricly_test.go
@@ -56,7 +56,7 @@ func TestConvertDataBatchToElements(t *testing.T) {
 	//given
 	batch := createDataBatch()
 	//when
-	elements := DataBatchToElements(metricly.MetriclyConfig{}, NewMetricCache(300), batch)
+	elements := DataBatchToElements("", metricly.MetriclyConfig{}, NewMetricCache(300), batch)
 	//then
 	if len(elements) != 1 {
 		t.Errorf("There should be 1 element in elements, but actual =  %d", len(elements))


### PR DESCRIPTION
fixes #14 add support for a configurable cluster name in Metricly Sink