### PR TITLE
use its original import path since our repo is a fork

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ go:
   - 1.8
 
 before_install:
-  - go get -d -t github.com/metricly/go-client
+  - go get -d github.com/metricly/go-client
 
 script:
   - make metricly

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ go:
   - 1.8
 
 before_install:
-  - go get -t github.com/metricly/go-client
+  - go get -d -t github.com/metricly/go-client
 
 script:
   - make metricly

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ go:
   - 1.8
 
 before_install:
-  - go get -d github.com/metricly/go-client
+  - go get -d github.com/metricly/go-client/api
+  - go get -d github.com/metricly/go-client/model/core
 
 script:
   - make metricly

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ sudo: required
 
 language: go
 
+go_import_path: k8s.io/heapster
+
 services:
   - docker
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ services:
 go:
   - 1.8
 
+before_install:
+  - go get -t github.com/metricly/go-client
+
 script:
   - make metricly
 


### PR DESCRIPTION
fixes #20 by using its original go import path for heapster in travis

